### PR TITLE
Fixed broken librosa logic (and formatted it using Ruff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# PyPMV
-PyPMV is a Python script for generating YTPMV audio and visuals, all in one!
+# PyPMV-RosaFix
+PyPMV is a Python script for generating YTPMV audio and visuals, all in one! 
+This fork aims to fix the librosa bug found in recent version of PyPMV, which makes the program unusable. 
+This is due to librosa having a different way of doing the time_stretch() function in newer versions, meaning running the old time_stretch() logic would break the script.
 # Requirements
 - Python
 # Usage

--- a/main.py
+++ b/main.py
@@ -1,13 +1,21 @@
-import os
 import argparse
-from moviepy.editor import *
-import pretty_midi
+import os
+
 import librosa
+import pretty_midi
 import soundfile as sf
+from moviepy.editor import VideoFileClip, AudioFileClip, CompositeVideoClip
+
 parser = argparse.ArgumentParser(prog="PyPMV")
 parser.add_argument("-m", "--midi", required=True, help="Path to the MIDI file")
 parser.add_argument("-c", "--clip", required=True, help="Path to the video clip file")
-parser.add_argument("-o", "--output", required=False, help="Path to the output video file", default="output.mp4")
+parser.add_argument(
+    "-o",
+    "--output",
+    required=False,
+    help="Path to the output video file",
+    default="output.mp4",
+)
 args = parser.parse_args()
 midiFile = pretty_midi.PrettyMIDI(args.midi)
 notes = []
@@ -24,8 +32,10 @@ for note in notes:
     audio = clip1.audio
     audio.to_audiofile("temp.wav")
     y, sr = librosa.load("temp.wav")
-    y = librosa.effects.time_stretch(y, clip1.duration / (note.end - note.start))
-    y = librosa.effects.pitch_shift(y, sr, n_steps=(note.pitch - 60), bins_per_octave=12)
+    y = librosa.effects.time_stretch(y, rate=clip1.duration / (note.end - note.start))
+    y = librosa.effects.pitch_shift(
+        y, sr=sr, n_steps=(note.pitch - 60), bins_per_octave=12
+    )
     sf.write("temp2.wav", y, sr)
     audio = AudioFileClip("temp2.wav")
     clip = clip.set_audio(audio)


### PR DESCRIPTION
librosa has a different way of doing the time_stretch() function in newer versions, meaning running the old time_stretch() logic would break the script and it wouldn't run. This, however, fixes this issue.

Also, I formatted the script using the Ruff formatter for VSCode because dawg you needa make your code a little more viewable :skull: 